### PR TITLE
Support VerifyingKey for public key (certificate) slots

### DIFF
--- a/src/client/verifying.rs
+++ b/src/client/verifying.rs
@@ -33,8 +33,11 @@ where
 
     pub async fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         let digest = self.atca.sha().digest(msg).await?;
-        let key_id = self.key_id;
-        let public_key = self.atca.generate_pubkey(key_id).await?;
+        let public_key = if self.key_id.is_certificate() {
+            self.atca.memory().pubkey(self.key_id).await?
+        } else {
+            self.atca.generate_pubkey(self.key_id).await?
+        };
         self.verify_digest(&digest, signature, &public_key).await
     }
 }
@@ -58,8 +61,11 @@ where
 
     pub fn verify_blocking(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         let digest = self.atca.sha().digest_blocking(msg)?;
-        let key_id = self.key_id;
-        let public_key = self.atca.generate_pubkey_blocking(key_id)?;
+        let public_key = if self.key_id.is_certificate() {
+            self.atca.memory().pubkey_blocking(self.key_id)?
+        } else {
+            self.atca.generate_pubkey_blocking(self.key_id)?
+        };
         self.verify_digest_blocking(&digest, signature, &public_key)
     }
 }


### PR DESCRIPTION
## Summary

- `VerifyingKey::verify` and `verify_blocking` previously called `generate_pubkey()`, which only works for private key slots (0x00–0x07) — it derives the public key from the stored private key
- For certificate/public key slots (0x09–0x0f), there is no private key to derive from, so `generate_pubkey()` fails
- This adds a branch on `Slot::is_certificate()` to use `memory().pubkey()` (which reads the stored public key directly) for certificate slots, and keeps `generate_pubkey()` for private key slots
- Enables `client.verifier(slot)` to work with external public keys stored in certificate slots (e.g. code signing keys)