### PR TITLE
Fix swapped Zone enum values breaking all data zone operations

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -418,20 +418,24 @@ impl<'a> Lock<'a> {
     }
 
     pub(crate) fn zone(&mut self, zone: Zone, crc: Option<u16>) -> Result<Packet, Error> {
-        if matches!(zone, Zone::Otp) {
-            return Err(ErrorKind::BadParam.into());
-        }
+        // Lock command uses its own zone encoding (bit 0: 0=Config, 1=Data/OTP),
+        // which differs from Read/Write (bits 1:0: 00=Config, 01=OTP, 02=Data).
+        let lock_zone = match zone {
+            Zone::Config => 0x00,
+            Zone::Data => 0x01,
+            Zone::Otp => return Err(ErrorKind::BadParam.into()),
+        };
 
         let packet = match crc {
             None => self
                 .0
                 .opcode(OpCode::Lock)
-                .mode(Self::LOCK_ZONE_NO_CRC | zone as u8)
+                .mode(Self::LOCK_ZONE_NO_CRC | lock_zone)
                 .build()?,
             Some(crc) => self
                 .0
                 .opcode(OpCode::Lock)
-                .mode(zone as u8)
+                .mode(lock_zone)
                 .param2(crc)
                 .build()?,
         };

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -23,8 +23,8 @@ impl Size {
 #[derive(Copy, Clone, Debug)]
 pub enum Zone {
     Config = 0x00,
-    Data = 0x01,
-    Otp = 0x02,
+    Otp = 0x01,
+    Data = 0x02,
 }
 
 impl Zone {


### PR DESCRIPTION
## Summary

- `Zone::Data` was `0x01` and `Zone::Otp` was `0x02`, but the ATECC608A spec defines `OTP=0x01` and `Data=0x02`. Every Read/Write targeting the data zone sent OTP in the mode byte instead, causing the ATECC to reject with Parse error (`0x03`).
- Config zone operations were unaffected (`Config=0x00` was correct), and Lock commands happened to work because Lock uses a different zone encoding (bit 0: 0=Config, 1=Data) that accidentally matched the wrong value. Lock now maps `Zone` to its own encoding independently.
- This went undetected because firmware never used data zone Read/Write after lock — only GenKey/Sign (which don't use the Zone enum) and config zone reads.