### PR TITLE
feat: re-export Serial for SubjectSource::FromSerial consumers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod packet;
 pub mod tngtls;
 
 pub use client::{Aes, AtCaClient, Memory, Random, Sha, SigningKey, VerifyingKey};
-pub use command::{Block, Digest, PublicKey};
+pub use command::{Block, Digest, PublicKey, Serial};
 pub use datalink::I2cConfig;
 pub use packet::CRC16;
 pub use signature;


### PR DESCRIPTION
## Summary

`SubjectSource::FromSerial(fn(&Serial, &mut [u8]) -> Option<usize>)` (added in #39) is part of the public API, but `Serial` itself is only `pub use`d as part of nothing — `command` is private and just `Block`/`Digest`/`PublicKey` are re-exported. A downstream crate therefore cannot name `Serial` to define its derivation function, making the `FromSerial` variant unconstructable outside the crate.

Re-exports `Serial` alongside the other public `command` types.