### PR TITLE
fix(memory): derive read_certificate pubkey via GenKey for private-key slots

### DIFF
--- a/src/client/memory.rs
+++ b/src/client/memory.rs
@@ -52,6 +52,17 @@ where
         Ok(pubkey)
     }
 
+    /// Derive the public key of a private-key slot via GenKey.
+    ///
+    /// A private-key slot is secret and cannot be read back with [`Self::pubkey`]
+    /// (the device rejects the Read with an execution error); its public key is
+    /// recomputed from the stored private key instead.
+    pub async fn gen_pubkey(&mut self, key_id: Slot) -> Result<PublicKey, Error> {
+        let mut inner = self.atca.inner.lock().await;
+        let packet = command::GenKey::new(inner.packet_builder()).public_key(key_id)?;
+        inner.execute(packet).await?.as_ref().try_into()
+    }
+
     pub async fn write_pubkey(&mut self, key_id: Slot, pubkey: &[u8]) -> Result<(), Error> {
         let mut data = Block::default();
         let mut offset = 0;
@@ -321,7 +332,13 @@ where
         output: &mut [u8],
     ) -> Result<usize, Error> {
         let compressed = self.read_compressed_cert(def.compressed_slot).await?;
-        let public_key = self.pubkey(def.public_key_slot).await?;
+        // A private-key slot is secret: its public key must be derived via
+        // GenKey, not read back. Public-key / cert slots are read directly.
+        let public_key = if def.public_key_slot.is_private_key() {
+            self.gen_pubkey(def.public_key_slot).await?
+        } else {
+            self.pubkey(def.public_key_slot).await?
+        };
 
         let mut serial_buf = [0u8; 32];
         let serial: &[u8] = if let SerialSource::Stored(addr) = &def.serial_source {
@@ -440,6 +457,17 @@ where
         }
 
         Ok(pubkey)
+    }
+
+    /// Blocking counterpart to [`Self::gen_pubkey`].
+    pub fn gen_pubkey_blocking(&mut self, key_id: Slot) -> Result<PublicKey, Error> {
+        let mut inner = self
+            .atca
+            .inner
+            .try_lock()
+            .map_err(|_| ErrorKind::MutexLocked)?;
+        let packet = command::GenKey::new(inner.packet_builder()).public_key(key_id)?;
+        inner.execute_blocking(packet)?.as_ref().try_into()
     }
 
     pub fn write_pubkey_blocking(&mut self, key_id: Slot, pubkey: &[u8]) -> Result<(), Error> {
@@ -751,7 +779,13 @@ where
         output: &mut [u8],
     ) -> Result<usize, Error> {
         let compressed = self.read_compressed_cert_blocking(def.compressed_slot)?;
-        let public_key = self.pubkey_blocking(def.public_key_slot)?;
+        // A private-key slot is secret: its public key must be derived via
+        // GenKey, not read back. Public-key / cert slots are read directly.
+        let public_key = if def.public_key_slot.is_private_key() {
+            self.gen_pubkey_blocking(def.public_key_slot)?
+        } else {
+            self.pubkey_blocking(def.public_key_slot)?
+        };
 
         let mut serial_buf = [0u8; 32];
         let serial: &[u8] = if let SerialSource::Stored(addr) = &def.serial_source {


### PR DESCRIPTION
## Summary

`read_certificate` reconstructed the subject public key with a raw slot `Read` (`Memory::pubkey`). When `public_key_slot` points at a **secret private-key slot** — as the device claim/provisioned certificate definitions do — the ATECC608 refuses the Read and returns `Status::Execution` (0x0F). So `read_certificate` always failed on those certs even though `write_certificate` had stored a valid compressed cert (write embeds the pubkey from the DER and never reads the slot, so the two paths were asymmetric).

The public key of a private-key slot can only be obtained via **GenKey**. This dispatches on `Slot::is_private_key()`:
- private-key slot → `gen_pubkey` (GenKey)
- public-key / cert slot → `pubkey` (raw Read, unchanged)

This honors the existing `public_key_slot` doc comment ("Slot where public key is stored *or generated from*"), which the implementation never actually honored.

Changes:
- Add `Memory::gen_pubkey` / `gen_pubkey_blocking`.
- Dispatch in both `read_certificate` and `read_certificate_blocking`.

## Verification
- All 21 existing unit tests pass.
- Verified on a Factbird DUO over a debug probe: before the fix `read_certificate` returned `Status::Execution` (0x0F); after, it reconstructs the migrated ECC claim cert byte-correctly — openssl confirms `CN=<device uuid>`, issuer `CN=Fleet CA`, P-256, valid ECDSA-SHA256 signature.