### PR TITLE
fix(tls): accept server-presented trust anchor in chain verification

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -265,6 +265,11 @@ where
                 .map_err(|_| TlsError::InvalidCertificate)?,
         };
 
+        // Trust is anchored on this configured key, not on a server-presented
+        // copy of the root. Kept separate from `ca_pubkey`, which mutates as we
+        // descend the chain.
+        let anchor_pubkey = ca_pubkey;
+
         let mut cn = None;
 
         // Walk the chain from the entry closest to CA (last) down to the leaf (first).
@@ -278,6 +283,25 @@ where
 
             let parsed =
                 DecodedCertificate::from_der(cert_data).map_err(|_| TlsError::DecodeError)?;
+
+            // Extract this cert's public key up front so a server-presented copy
+            // of the trust anchor can be recognised before any verification.
+            let spki_bytes = parsed
+                .tbs_certificate
+                .subject_public_key_info
+                .public_key
+                .as_bytes()
+                .ok_or(TlsError::DecodeError)?;
+            let cert_pubkey = sec1_to_raw_pubkey(spki_bytes)?;
+
+            // A server MAY include the (cross-signed) root in the chain
+            // (RFC 8446 4.4.2). We already trust the anchor by its public key, so
+            // skip a presented copy of it rather than verifying it. The
+            // cross-signed Amazon Root CA 3 is RSA-signed and would otherwise
+            // trip the ECDSA-only check below.
+            if cert_pubkey.as_ref() == anchor_pubkey.as_ref() {
+                continue;
+            }
 
             // Only ECDSA P-256 SHA-256 is supported by the ATECC608
             if parsed.signature_algorithm.oid != ECDSA_SHA256_OID {
@@ -301,15 +325,6 @@ where
             self.atca
                 .verify_external_blocking(&digest, &signature, &ca_pubkey)
                 .map_err(|_| TlsError::InvalidCertificate)?;
-
-            // Extract this cert's public key for the next iteration (or as server key for leaf)
-            let spki_bytes = parsed
-                .tbs_certificate
-                .subject_public_key_info
-                .public_key
-                .as_bytes()
-                .ok_or(TlsError::DecodeError)?;
-            let cert_pubkey = sec1_to_raw_pubkey(spki_bytes)?;
 
             if i == 0 {
                 // Leaf certificate — extract CN and store server public key


### PR DESCRIPTION
## Summary

`AteccVerifier::verify_certificate` walked every certificate in the server-presented chain and required each one to be ECDSA-P256-SHA256 signed. AWS IoT ATS custom-domain endpoints (e.g. `provision.factbird.com:443`) present the full chain including the **cross-signed Amazon Root CA 3** as the last entry, whose signature is `sha256WithRSAEncryption` (Starfield Services Root CA - G2 cross-sign). That tripped the ECDSA-only check on the very first entry processed, failing every handshake with `InvalidSignatureScheme`.

Observed chain on `provision.factbird.com:443`:

| # | Subject | Issuer | Sig alg |
|---|---------|--------|---------|
| 1 (leaf) | provision.factbird.com | Amazon ECDSA 256 M01 | ecdsa-with-SHA256 |
| 2 (intermediate) | Amazon ECDSA 256 M01 | Amazon Root CA 3 | ecdsa-with-SHA256 |
| 3 (root) | Amazon Root CA 3 | Starfield Services Root CA - G2 | **sha256WithRSAEncryption** |

Trust is anchored on the configured CA public key, not on a server-presented copy of the root (RFC 8446 4.4.2 permits including it). This skips any presented entry whose SPKI equals the anchor key, **before** the ECDSA-scheme check and signature verification.

## Security

The skip is gated on an exact EC public-key match against the configured anchor:
- Fully-RSA chains still fail closed - an RSA SPKI cannot parse as a 65-byte SEC1 point (`sec1_to_raw_pubkey`), so it is never skipped, and RSA-signed EC certs still hit the ECDSA-only check.
- The skip never advances the verifying key to an attacker-controlled value; a cert carrying the anchor's public key is inert (nothing is extracted from it).
- Net effect narrows a false rejection; it does not widen the accepted set beyond an all-ECDSA chain rooted at the pinned Amazon Root CA 3 key.